### PR TITLE
fix: automatic session reconnection on timeout and 401/403 errors

### DIFF
--- a/src/aws_abap_accelerator/sap/sap_client.py
+++ b/src/aws_abap_accelerator/sap/sap_client.py
@@ -110,14 +110,8 @@ class SAPADTClient:
         """Ensure HTTP session is valid and recreate if needed"""
         if self.session is None or self.session.closed:
             logger.info("Creating new HTTP session (previous session was closed)")
-            if self.session and not self.session.closed:
-                await self.session.close()
-            self.session = await self._create_session()
-            
-            # Re-authenticate if we had to recreate the session
-            if self.csrf_token:
-                logger.info("Re-authenticating after session recreation")
-                await self._authenticate_basic()
+            # Use connect() to handle all authentication priorities (Cert, Basic, Cookie)
+            await self.connect()
     
     async def _handle_session_timeout_error(self, response_status: int, response_text: str) -> bool:
         """
@@ -130,12 +124,15 @@ class SAPADTClient:
         Returns:
             True if session was refreshed and request should be retried, False otherwise
         """
-        # Check for session timeout indicators
+        # Check for session timeout or unauthorized (expired session) indicators
         is_session_timeout = (
-            response_status == 400 and 
+            (response_status in (400, 401, 403)) and 
             ('session timed out' in response_text.lower() or 
              'session timeout' in response_text.lower() or
-             'session expired' in response_text.lower())
+             'session expired' in response_text.lower() or
+             'unauthorized' in response_text.lower() or
+             'csrf token' in response_text.lower() or
+             'forbidden' in response_text.lower())
         )
         
         if not is_session_timeout:


### PR DESCRIPTION
### Summary
This PR fixes an issue where the ABAP Accelerator (MCP server) fails to automatically recover and reconnect when an SAP session expires or times out.

### Problem
Previously, the `_handle_session_timeout_error` method only checked for HTTP status `400` with specific error keywords. However, in real SAP environments, a session timeout or CSRF validation failure often returns HTTP `401 Unauthorized` or `403 Forbidden`. Consequently, subsequent MCP tool calls fail continuously without triggering a re-authentication.

Additionally, `_ensure_session_valid` only attempted to recreate a basic auth session when the session was closed, ignoring other connection methods such as client certificates or browser cookies.

### Proposed Changes
1. **Enhanced Timeout Detection:** Updated `_handle_session_timeout_error` to catch `401` and `403` status codes, as well as additional session-expired keywords (`unauthorized`, `csrf token`, `forbidden`).
2. **Unified Session Validation:** Modified `_ensure_session_valid` to call `self.connect()` directly when a session is closed. This leverages the client's existing authentication hierarchy (Certificate -> Basic -> Cookie) to securely and dynamically refresh the connection.