### PR TITLE
fix: connection_status probes the live session instead of reporting cached auth state

### DIFF
--- a/src/aws_abap_accelerator/sap/sap_client.py
+++ b/src/aws_abap_accelerator/sap/sap_client.py
@@ -711,6 +711,37 @@ class SAPADTClient:
             logger.error(f"Failed to get CSRF token: {sanitize_for_logging(str(e))}")
             return False
     
+    async def probe_session(self) -> Dict[str, Any]:
+        """Actively verify the ADT session is still valid, rather than trusting
+        cached auth state.
+
+        Issues one cheap authenticated read (the discovery document). A 200 means
+        the session is live; a 400 (``Session Timed Out``), 401 or 403 means the
+        cookies have expired even though we once authenticated — the exact case
+        where the cached status is misleadingly "Connected". Returns
+        ``{"session_valid": bool, "status": int|None, "detail": str}``.
+        """
+        if not self.session:
+            return {"session_valid": False, "status": None, "detail": "no session established"}
+        try:
+            url = f"/sap/bc/adt/discovery?sap-client={self.connection.client}"
+            headers = await self._get_appropriate_headers()
+            headers['Accept'] = 'application/atomsvc+xml, application/xml'
+            async with self.session.get(url, headers=headers) as response:
+                status = response.status
+                if status == 200:
+                    return {"session_valid": True, "status": status, "detail": "session valid"}
+                body = ""
+                try:
+                    body = (await response.text())[:200].strip()
+                except Exception:
+                    pass
+                detail = f"probe returned {status}" + (f": {body}" if body else "")
+                return {"session_valid": False, "status": status, "detail": detail}
+        except Exception as e:
+            return {"session_valid": False, "status": None,
+                    "detail": f"probe failed: {sanitize_for_logging(str(e))}"}
+
     async def get_current_user_info(self) -> Optional[Dict[str, str]]:
         """Get current user information from SAP system"""
         try:

--- a/src/aws_abap_accelerator/server/fastmcp_server.py
+++ b/src/aws_abap_accelerator/server/fastmcp_server.py
@@ -83,8 +83,16 @@ class ABAPAcceleratorServer:
                     await self._ensure_connected()
                 except Exception as e:
                     logger.error(f"Connection attempt failed: {sanitize_for_logging(str(e))}")
-            
-            return self.tool_handlers.handle_connection_status(self.connected)
+
+            # Actively probe the session instead of trusting the cached flag —
+            # a session can time out while self.connected is still True.
+            probe = None
+            try:
+                probe = await self.sap_client.probe_session()
+            except Exception as e:
+                logger.error(f"Session probe failed: {sanitize_for_logging(str(e))}")
+
+            return self.tool_handlers.handle_connection_status(self.connected, probe)
         
         # Get objects tool
         @self.mcp.tool()

--- a/src/aws_abap_accelerator/server/tool_handlers.py
+++ b/src/aws_abap_accelerator/server/tool_handlers.py
@@ -36,11 +36,24 @@ class ToolHandlers:
             logger.info("Successfully connected to SAP system")
         return True
     
-    def handle_connection_status(self, connected: bool) -> str:
-        """Handle connection status check"""
+    def handle_connection_status(self, connected: bool, probe: Optional[Dict[str, Any]] = None) -> str:
+        """Handle connection status check.
+
+        ``connected`` reflects whether we ever authenticated (cached state).
+        ``probe`` (from sap_client.probe_session) reflects whether the ADT
+        session is valid *right now* — the two differ once the session times out,
+        which is exactly when the cached status is misleading. Both are reported.
+        """
         try:
-            status = "Connected" if connected else "Disconnected"
-            
+            authenticated = "Yes" if connected else "No"
+            if probe is not None:
+                session_valid = probe.get("session_valid", False)
+                status = "Connected" if session_valid else "Session expired"
+            else:
+                # No probe supplied: fall back to cached state (legacy callers).
+                session_valid = None
+                status = "Connected" if connected else "Disconnected"
+
             connection_details = (
                 f"- Host: {self.sap_client.connection.host}\n"
                 f"- Client: {self.sap_client.connection.client}\n"
@@ -61,8 +74,21 @@ class ToolHandlers:
                     f"- Username: {self.sap_client.connection.username}"
                 )
             
-            return f"SAP Connection Status: {status}\n\nConnection Details:\n{connection_details}"
-            
+            # Distinguish "authenticated" (cached) from "session valid" (probed),
+            # so a timed-out session is not reported as healthy.
+            session_lines = [f"- Authenticated: {authenticated}"]
+            if probe is not None:
+                session_lines.append(f"- Session valid (probed): {'Yes' if session_valid else 'No'}")
+                if not session_valid and probe.get("detail"):
+                    session_lines.append(f"- Probe detail: {probe['detail']}")
+            session_block = "\n".join(session_lines)
+
+            return (
+                f"SAP Connection Status: {status}\n\n"
+                f"Session:\n{session_block}\n\n"
+                f"Connection Details:\n{connection_details}"
+            )
+
         except Exception as e:
             logger.error(f"Error getting connection status: {sanitize_for_logging(str(e))}")
             return f"Error getting connection status: {sanitize_for_logging(str(e))}"


### PR DESCRIPTION
Relates to #10 (same "success-shaped result for a non-functional state" pattern; `connection_status` is not among that issue's enumerated tools, so this is a related fix rather than a strict close).

## Problem
`connection_status` reported "Connected" from a cached flag set at first authentication, so it stayed green through session timeouts — the one tool a user reaches for to answer *"is the bridge healthy?"* answered yes while every read was failing with `400 Session Timed Out`.

## Fix
It now issues one cheap authenticated read (the discovery document) via a new `probe_session()` and reports two distinct facts: **Authenticated** (did we ever auth) and **Session valid (probed)** (is the session live right now).

## Verification (live, S/4HANA)
- Healthy session → `Session valid (probed): Yes`.
- Dropped/expired session → `Session expired`, status 401/400, instead of a false "Connected".