### PR TITLE
docs(readme): document a durable server launch and the venv symlink trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,24 @@ cd guidance-for-deploying-sap-abap-accelerator-for-amazon-q-developer
 # Install dependencies
 pip install -r requirements.txt
 
-# Run the server
+# Run the server (foreground, for development)
 python src/aws_abap_accelerator/main.py
 ```
+
+To keep the server running independently of the launching shell, start it
+detached and log to a file so a failure is diagnosable rather than silent — a
+bare `&` dies with the shell it was launched from:
+
+```bash
+nohup python src/aws_abap_accelerator/main.py > mcp-server.log 2>&1 &
+disown
+```
+
+> **If you run in a virtual environment, launch via the interpreter path itself
+> (`.venv/bin/python …`), never a resolved/canonicalised path.** `.venv/bin/python`
+> is a symlink to the base interpreter; resolving the symlink and launching the
+> real path bypasses the virtualenv's `site-packages`, so the server fails to
+> start with import errors. Tools or scripts that canonicalise paths hit this.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Problem
The Setup section showed only a foreground launch (`python … main.py`). A bare `&` dies with the launching shell, and there is no default log, so a background failure is silent. Separately, launching a virtualenv's interpreter via a *resolved* symlink path silently bypasses its `site-packages`.

## Fix
- Add a detached, log-to-file launch: `nohup python … > mcp-server.log 2>&1 &` then `disown`.
- Warn that when using a virtualenv the server must be launched via the `.venv/bin/python` path itself, not a resolved symlink, or it starts with import errors.

Doc-only; no code change.